### PR TITLE
Get client certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,5 +99,52 @@ $ go run main.go
 # Certificate loaded once the certificate and key can both be read correctly and they match
 ```
 
+Certman also implements `GetClientCertificate` for client mTLS certificates:
+```go
+package main
+
+import (
+	"crypto/tls"
+	"io"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/dyson/certman"
+)
+
+func main() {
+	logger := log.New(os.Stdout, "", log.LstdFlags)
+
+	cm, err := certman.New("client.crt", "client.key")
+	if err != nil {
+		logger.Println(err)
+	}
+	cm.Logger(logger)
+	if err := cm.Watch(); err != nil {
+		logger.Println(err)
+	}
+
+	c := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				GetClientCertificate: cm.GetClientCertificate,
+			},
+		},
+	}
+	res, err := c.Get("https://example.net")
+	if err != nil {
+		logger.Println(err)
+	}
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		logger.Println(err)
+	}
+
+	logger.Printf("Got Response: %s", body)
+}
+```
+
 ## License
 See LICENSE file.
+

--- a/certman.go
+++ b/certman.go
@@ -147,6 +147,13 @@ func (cm *CertMan) GetCertificate(hello *tls.ClientHelloInfo) (*tls.Certificate,
 	return cm.keyPair, nil
 }
 
+// GetClientCertificate returns the loaded certificate for use
+// by the TLSConfig fields GetClientCerfificate field in a
+// http.Server.
+func (cm *CertMan) GetClientCertificate(_ *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+	return cm.GetCertificate(nil)
+}
+
 // Stop tells certMan to stop watching for changes to the
 // certificate and key files.
 func (cm *CertMan) Stop() {

--- a/certman_test.go
+++ b/certman_test.go
@@ -255,6 +255,34 @@ func TestGetCertificate(t *testing.T) {
 
 }
 
+func TestGetClientCertificate(t *testing.T) {
+	cm, err := certman.New("./testdata/server1.crt", "./testdata/server1.key")
+	if err != nil {
+		t.Fatalf("could not create certman: %v", err)
+	}
+
+	if err := cm.Watch(); err != nil {
+		t.Fatalf("could not watch files: %v", err)
+	}
+
+	hello := &tls.CertificateRequestInfo{}
+
+	cmCert, err := cm.GetClientCertificate(hello)
+	if err != nil {
+		t.Fatalf("could not get certman certificate")
+	}
+
+	expectedCert, _ := tls.LoadX509KeyPair("./testdata/server1.crt", "./testdata/server1.key")
+	if err != nil {
+		t.Fatalf("could not load certificate and key files to test: %v", err)
+	}
+
+	if !reflect.DeepEqual(cmCert.Certificate, expectedCert.Certificate) {
+		t.Fatalf("certman certificate doesn't match expected certificate")
+	}
+
+}
+
 func copyPair(crt, key string) {
 	// ignore error handling
 	crtSource, _ := os.Open(crt)


### PR DESCRIPTION
Similar to server certs, `tls.Config` supports setting a function to
fetch client certificates for http / tls clients. Like server
certificates, it can be useful to have these auto reload if an
application uses a long-lived client.